### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "author": "ConfigCat",
     "license": "MIT",
     "dependencies": {
-        "configcat-common": "1.1.16",
-        "npm": "^6.9.0"
+        "configcat-common": "1.1.16"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",


### PR DESCRIPTION

Hello configcat!

It seems like you have npm as one of your (dev-) dependency in js-sdk.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
