### PR TITLE
Remove IConfigFetcher type re-export

### DIFF
--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -35,5 +35,3 @@ export class HttpConfigFetcher implements IConfigFetcher {
         httpRequest.send(null);
     }
 }
-
-export default IConfigFetcher;


### PR DESCRIPTION
### Problem

Some issue in Typescript (which I wasn't able to actually find reported unfortunately) leads to a type-only import `IConfigFetcher` being left in generated `configcat-js/lib/esm/ConfigFetcher.js`:

```js
import { IConfigFetcher, ProjectConfig } from "configcat-common";
var HttpConfigFetcher = /** @class */ (function () {
    function HttpConfigFetcher() {
    }
//...
```

That problem breaks building projects depending on `configcat-js` using `esbuild` and bundlers based on it, such as `vite` and potentially others:

```
[vite] error while updating dependencies:
Error: Build failed with 1 error:
../../node_modules/configcat-js/lib/esm/ConfigFetcher.js:1:9: error: No matching export for import "IConfigFetcher"
    at failureErrorWithLog (<redacted>/node_modules/esbuild/lib/main.js:1170:15)
    at buildResponseToResult (<redacted>/node_modules/esbuild/lib/main.js:906:32)
    at <redacted>/node_modules/esbuild/lib/main.js:1001:20
    at <redacted>/node_modules/esbuild/lib/main.js:553:9
    at handleIncomingPacket (<redacted>/node_modules/esbuild/lib/main.js:642:9)
    at Socket.readFromStdout (<redacted>/node_modules/esbuild/lib/main.js:520:7)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:309:12)
    at readableAddChunk (_stream_readable.js:284:9)
    at Socket.Readable.push (_stream_readable.js:223:10)
```


### Describe the solution you've provided

This PR just removes the re-export of `IConfigFetcher` which makes generated `configcat-js/lib/esm/ConfigFetcher.js` look as expected:

```js
import { ProjectConfig } from "configcat-common";
var HttpConfigFetcher = /** @class */ (function () {
    function HttpConfigFetcher() {
    }
//...
```

This also stops `IConfigFetcher` from being exported from `configcat-js/lib/esm/ConfigFetcher.d.ts` which could be a breaking change and also might not be a desired outcome at all.

In that case the alternative solution would changing `IConfigFetcher` to explicit type-only one, i.e.:

```ts
import { ProjectConfig, OptionsBase } from "configcat-common";
import type { IConfigFetcher } from "configcat-common"
```

That would both stop `IConfigFetcher` from appearing in `ConfigFetcher.js` and leave it re-exported from `ConfigFetcher.d.ts`.
