### PR TITLE
Remove cache / cc user agent headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "configcat-js",
-    "version": "5.10.0",
+    "version": "6.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "configcat-js",
-            "version": "5.10.0",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
-                "configcat-common": "^5.3.0"
+                "configcat-common": "^6.0.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.2.12",
@@ -2758,9 +2758,9 @@
             }
         },
         "node_modules/configcat-common": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-5.3.0.tgz",
-            "integrity": "sha512-yM9SNuG8XQa0aHNK5eUhtzAD+a6yFEOQw0qg6f/ZvIWGHkY+7FYvDbSkvMHW1ERQaUmAIt2QLZB6rMJzFCDCmg=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-6.0.0.tgz",
+            "integrity": "sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA=="
         },
         "node_modules/connect": {
             "version": "3.7.0",
@@ -13475,9 +13475,9 @@
             }
         },
         "configcat-common": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-5.3.0.tgz",
-            "integrity": "sha512-yM9SNuG8XQa0aHNK5eUhtzAD+a6yFEOQw0qg6f/ZvIWGHkY+7FYvDbSkvMHW1ERQaUmAIt2QLZB6rMJzFCDCmg=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/configcat-common/-/configcat-common-6.0.0.tgz",
+            "integrity": "sha512-C/lCeTKiFk9kPElRF3f4zIkvVCLKgPJuzrKbIMHCru89mvfH5t4//hZ9TW8wPJOAje6xB6ZALutDiIxggwUvWA=="
         },
         "connect": {
             "version": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "configcat-js",
-    "version": "5.10.0",
+    "version": "6.0.0",
     "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
@@ -33,7 +33,7 @@
     "license": "MIT",
     "homepage": "https://configcat.com",
     "dependencies": {
-        "configcat-common": "^5.3.0"
+        "configcat-common": "^6.0.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.12",

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -25,11 +25,6 @@ export class HttpConfigFetcher implements IConfigFetcher {
 
         httpRequest.open("GET", options.getUrl(), true);
         httpRequest.timeout = options.requestTimeoutMs;
-        httpRequest.setRequestHeader("X-ConfigCat-UserAgent", options.clientVersion);
-        httpRequest.setRequestHeader("Cache-Control", "no-cache"); // any locally cached version isn't trusted without the server's say-so
-        if (lastEtag) {
-            httpRequest.setRequestHeader("If-None-Match", lastEtag);
-        }
         httpRequest.send(null);
     }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR removes the `If-None-Match` and `X-ConfigCat-UserAgent` request headers. The SDK is now a query param in the fetch URL, and we let the browser send the `If-None-Match` and `If-Modified-Since` headers.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
