### PR TITLE
Latin1fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-js",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-js",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "configcat-common": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-js",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -20,6 +20,8 @@ export class LocalStorageCache implements IConfigCatCache {
     catch (ex) {
       // local storage is unavailable or invalid cache value in localstorage
     }
+
+    return void 0;
   }
 
   private b64EncodeUnicode(str: string): string {

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -3,7 +3,7 @@ import type { IConfigCatCache } from "configcat-common";
 export class LocalStorageCache implements IConfigCatCache {
   set(key: string, value: string): void {
     try {
-      localStorage.setItem(key, btoa(value));
+      localStorage.setItem(key, this.b64EncodeUnicode(value));
     }
     catch (ex) {
       // local storage is unavailable
@@ -14,11 +14,23 @@ export class LocalStorageCache implements IConfigCatCache {
     try {
       const configString = localStorage.getItem(key);
       if (configString) {
-        return atob(configString);
+        return this.b64DecodeUnicode(configString);
       }
     }
     catch (ex) {
       // local storage is unavailable or invalid cache value in localstorage
     }
+  }
+
+  private b64EncodeUnicode(str: string): string {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
+      return String.fromCharCode(parseInt(p1, 16))
+    }))
+  }
+
+  private b64DecodeUnicode(str: string): string {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), function (c) {
+      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    }).join(''))
   }
 }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -25,13 +25,13 @@ export class LocalStorageCache implements IConfigCatCache {
   }
 
   private b64EncodeUnicode(str: string): string {
-    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (match, p1) {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (_, p1) {
       return String.fromCharCode(parseInt(p1, 16))
     }))
   }
 
   private b64DecodeUnicode(str: string): string {
-    return decodeURIComponent(Array.prototype.map.call(atob(str), function (c) {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), function (c: string) {
       return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
     }).join(''))
   }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -20,19 +20,18 @@ export class LocalStorageCache implements IConfigCatCache {
     catch (ex) {
       // local storage is unavailable or invalid cache value in localstorage
     }
-
     return void 0;
   }
 
   private b64EncodeUnicode(str: string): string {
     return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (_, p1) {
       return String.fromCharCode(parseInt(p1, 16))
-    }))
+    }));
   }
 
   private b64DecodeUnicode(str: string): string {
     return decodeURIComponent(Array.prototype.map.call(atob(str), function (c: string) {
       return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-    }).join(''))
+    }).join(''));
   }
 }

--- a/test/CacheTests.ts
+++ b/test/CacheTests.ts
@@ -1,0 +1,14 @@
+import { assert } from "chai";
+import { LocalStorageCache } from "../lib/Cache";
+
+
+describe("LocalStorageCache cache tests", () => {
+    it("LocalStorageCache works with non latin 1 characters", () => {
+        const cache = new LocalStorageCache();
+        const key = "testkey";
+        const text = "äöüÄÖÜçéèñışğâ¢™✓😀";
+        cache.set(key, text);
+        const retrievedValue = cache.get(key);
+        assert.equal(retrievedValue, text);
+    });
+});

--- a/test/CacheTests.ts
+++ b/test/CacheTests.ts
@@ -9,6 +9,6 @@ describe("LocalStorageCache cache tests", () => {
         const text = "äöüÄÖÜçéèñışğâ¢™✓😀";
         cache.set(key, text);
         const retrievedValue = cache.get(key);
-        assert.equal(retrievedValue, text);
+        assert.strictEqual(retrievedValue, text);
     });
 });

--- a/test/HttpTests.ts
+++ b/test/HttpTests.ts
@@ -5,7 +5,7 @@ import { FakeLogger } from "./helpers/fakes";
 import * as utils from "./helpers/utils";
 
 describe("HTTP tests", () => {
-  const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
+  const sdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ";
   const baseUrl = "https://cdn-global.test.com";
 
   it("HTTP timeout", async () => {

--- a/test/IntegrationTests.ts
+++ b/test/IntegrationTests.ts
@@ -3,7 +3,7 @@ import { IConfigCatClient, IEvaluationDetails, IOptions, LogLevel, PollingMode, 
 import * as configcatClient from "../src";
 import { createConsoleLogger } from "../src";
 
-const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
+const sdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ";
 
 describe("Integration tests - Normal use", () => {
 

--- a/test/SpecialCharacterTests.ts
+++ b/test/SpecialCharacterTests.ts
@@ -1,0 +1,31 @@
+import { assert } from "chai";
+import { IConfigCatClient, IEvaluationDetails, IOptions, LogLevel, PollingMode, SettingKeyValue, User } from "configcat-common";
+import * as configcatClient from "../src";
+import { createConsoleLogger } from "../src";
+
+const sdkKey = "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g";
+
+describe("Special characters test", () => {
+
+    const options: IOptions = { logger: createConsoleLogger(LogLevel.Off) };
+
+    let client: IConfigCatClient;
+
+    beforeEach(function () {
+        client = configcatClient.getClient(sdkKey, PollingMode.AutoPoll, options);
+    });
+
+    afterEach(function () {
+        client.dispose();
+    });
+
+    it(`Special characters works - cleartext`, async () => {
+        const actual: string = await client.getValueAsync("specialCharacters", "NOT_CAT", new User("äöüÄÖÜçéèñışğâ¢™✓😀"));
+        assert.strictEqual(actual, "äöüÄÖÜçéèñışğâ¢™✓😀");
+    });
+
+    it(`Special characters works - hashed`, async () => {
+        const actual: string = await client.getValueAsync("specialCharactersHashed", "NOT_CAT", new User("äöüÄÖÜçéèñışğâ¢™✓😀"));
+        assert.strictEqual(actual, "äöüÄÖÜçéèñışğâ¢™✓😀");
+    });
+});


### PR DESCRIPTION
### Describe the purpose of your pull request

The localstorage cache is not working with non Latin 1 characters.
Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
