### PR TITLE
Send etag as query param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-js",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-js",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "license": "MIT",
       "dependencies": {
         "configcat-common": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-js",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -35,7 +35,11 @@ export class HttpConfigFetcher implements IConfigFetcher {
         httpRequest.onabort = () => reject(new FetchError("abort"));
         httpRequest.onerror = () => reject(new FetchError("failure"));
 
-        httpRequest.open("GET", options.getUrl(), true);
+        let url = options.getUrl();
+        if (lastEtag) {
+          url += '&ccetag=' + lastEtag;
+        }
+        httpRequest.open("GET", url, true);
         httpRequest.timeout = options.requestTimeoutMs;
         // NOTE: It's intentional that we don't specify the If-None-Match header.
         // The browser automatically handles it, adding it manually would cause an unnecessary CORS OPTIONS request.

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -37,12 +37,14 @@ export class HttpConfigFetcher implements IConfigFetcher {
 
         let url = options.getUrl();
         if (lastEtag) {
+          // We are sending the etag as a query parameter so if the browser doesn't automatically adds the If-None-Match header, we can transorm this query param to the header in our CDN provider.
           url += '&ccetag=' + lastEtag;
         }
         httpRequest.open("GET", url, true);
         httpRequest.timeout = options.requestTimeoutMs;
         // NOTE: It's intentional that we don't specify the If-None-Match header.
         // The browser automatically handles it, adding it manually would cause an unnecessary CORS OPTIONS request.
+        // In case the browser doesn't handle it, we are transforming the ccetag query parameter to the If-None-Match header in our CDN provider.
         httpRequest.send(null);
       }
       catch (err) {


### PR DESCRIPTION
### Describe the purpose of your pull request

Send etag as a query param, so we can set the If-None-Match header in a CF transform rule if the browser is not sending it.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
